### PR TITLE
Fix missing dependency 'org.plazmamc.plazma:dev-bundle:1.20.1'

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Publish Packages
         if: github.ref_name == env.MAIN_BRANCH
         run: |
-          export GITHUB_USERNAME=${{ env.ORG_NAME }}
+          export GITHUB_USERNAME=${{ github.repository_owner }}
           export GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           ./gradlew publish --stacktrace
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -139,3 +139,11 @@ tasks {
         }
     }
 }
+
+publishing {
+    publications.create<MavenPublication>("devBundle") {
+        artifact(tasks.generateDevelopmentBundle) {
+            artifactId = "dev-bundle"
+        }
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,7 +33,7 @@ allprojects {
         repositories {
             maven {
                 name = "githubPackage"
-                url = uri("https://maven.pkg.github.com/PlazmaMC/PlazmaBukkit")
+                url = uri("https://maven.pkg.github.com/${System.getenv("GITHUB_REPOSITORY")}")
 
                 credentials {
                     username = System.getenv("GITHUB_USERNAME")


### PR DESCRIPTION
The dependency for version 1.20.4 is published, but the dependency for version 1.20.1 is not.

[org.plazmamc.plazma.dev-bundle / All Versions](https://github.com/PlazmaMC/PlazmaBukkit/packages/2048008/versions)
![image](https://github.com/PlazmaMC/PlazmaBukkit/assets/71868623/f9fd1c27-ccb3-4379-ae47-01d2ae95b467)